### PR TITLE
search: remove iTunes collectionView

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -10,7 +10,6 @@ var resp = new Resp({
     console.log('encountered an error', err);
   },
   "services": {
-    "gifs": {},
     "youtube": {},
     "iTunes": {},
   }
@@ -153,12 +152,6 @@ function makeiTunesSnippet(data, result, indent) {
     '	  <div class="itunesInfoTitle" data-btn=\'{"id":' + result.track_id + '}\'>' + (result.track_censored_name || result.title) + '</div>',
     '	  <div class="itunesInfoArtist"><a href="' + result.artist_view_url + '" target="_blank">' + result.artist_name + '</a></div>',
   ] ;
-
-  if (result.collection_name) {
-    previewElementElement.push(
-    '	  <div class="itunesInfoTitle"><a href="' + result.collection_view_url + '" target="_blank">' + result.collection_name + '</a></div>'
-    );
-  }
 
   if (result.track_price && result.currency) {
     previewElementElement.push(


### PR DESCRIPTION
Fixes #5

* Removes "collectionView" display on the iTunes results
card. Some items didn't have collection URLs and this was
causing ugly results. On top of that collections weren't
accounted for when designing each card so the display results
came out embarrasingly ugly. This PR removes collectionView
for iTunes results.
* Removes unnecessary search category "gifs" for which
these aren't even consumed despite having results processed for.
Save some bandwidth as well as processing power.

## Exhibit:

### Before
<img width="588" alt="screen shot 2017-07-12 at 12 12 22 am" src="https://user-images.githubusercontent.com/4898263/28104143-dbccfc10-6696-11e7-8ba8-9824a00ce8ff.png">


### After
<img width="588" alt="screen shot 2017-07-12 at 12 12 38 am" src="https://user-images.githubusercontent.com/4898263/28104146-e07b8696-6696-11e7-8e03-814198fff84f.png">
